### PR TITLE
Replace possibly arbitray atom indices with smaller numbers.

### DIFF
--- a/MOO/mol_and_orb/molecules_and_orbitals.cpp
+++ b/MOO/mol_and_orb/molecules_and_orbitals.cpp
@@ -1474,12 +1474,12 @@ vector <double> mol_and_orb::calcJ(mol_and_orb &A, mol_and_orb &B, mol_and_orb &
 	if (debug==1) {
 	    print();
 	    cout << shove1 << shove2;
-	    cout << "that was the original dymer";
+	    cout << "that was the original dymer" << endl;
 	}
 		
 	//now get the rotations
-	const int lbl1 = 12 ; 
-	const int lbl2 = 22 ;
+	const int lbl1 = 0; 
+	const int lbl2 = 1;
 	
 	coord tmp1, tmp2;
 	tmp1 = pos[lbl1]-shove1;


### PR DESCRIPTION
Replace possibly arbitray atom indices with smaller numbers when calculating relative rotations of molecules A and B. Fixes a source of segmentation faults I was getting when running J calculations on the napthelene structure in the examples directory. Selecting atom 22 led to crashes since napthalene only has 18 atoms.