### PR TITLE
Use smaller atom indices when calculating rotations between A and B.

### DIFF
--- a/src/mol_and_orb/molecules_and_orbitals.cpp
+++ b/src/mol_and_orb/molecules_and_orbitals.cpp
@@ -1478,8 +1478,8 @@ vector <double> mol_and_orb::calcJ(mol_and_orb &A, mol_and_orb &B, mol_and_orb &
 	}
 		
 	//now get the rotations
-	const int lbl1 = 12 ; 
-	const int lbl2 = 22 ;
+	const int lbl1 = 0; 
+	const int lbl2 = 1;
 	
 	coord tmp1, tmp2;
 	tmp1 = pos[lbl1]-shove1;


### PR DESCRIPTION
Replace possibly arbitray atom indices with smaller numbers when calculating relative rotations of molecules A and B. Fixes a source of segmentation faults. Selecting atom 22 led to crashes when running calculations on small molecules (such as napthalene in the examples directory, which has 18 atoms).

As far as I can tell, atoms indexed 12 and 22 aren't significant!